### PR TITLE
Add compact comparer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ https://nuget.org/packages/Verify.DiffPlex/
 
 ### Initialize
 
-Call `VerifyDiffPlex.Initialize()` once at assembly load time.
+Call `VerifyDiffPlex.Initialize()` once at assembly load time to get the default (full) diff output. Alternatively, you can use `VerifyDiffPlex.Initialize(OutputType.Full)` or `VerifyDiffPlex.Initialize(OutputType.Compact)` to specify the type of output (see below).
 
 
 ### Verify text
@@ -48,7 +48,7 @@ text";
 
 ### Diff results
 
-When the comparison fails, the resulting differences will be included in the test result displayed to the user.
+When the comparison fails, the resulting differences will be included in the test result displayed to the user. This example shows the `Full` style of output.
 
 ```txt
 Results do not match.
@@ -60,4 +60,38 @@ Compare Result:
 - before
 + after
   text
+```
+
+
+### Output types
+
+The library currently supports two different types of diff outputs; the desired type can be specified during library initialization.
+
+`OutputType.Full` is the default. It shows the full contents of the verified file, with differences with the received file indicated by `+` and `-`. Here's an example of `Full` output.
+
+```
+  First line
+- Second line
++ Second line changed
+  Third line
+  Fourth line
+  Fifth line
+- Sixth line
++ Sixth line changed
+  Seventh line
+  Eighth line
+```
+
+This output type gives the most information, but if your verified files are long, it can be difficult to read through and find the actual differences. `OutputType.Compact` will show only the changed lines, with one line of context before and after each changed section. The `Full` output above would look like this as `Compact`.
+
+```
+1   First line
+  - Second line
+  + Second line changed
+3   Third line
+
+5   Fifth line
+  - Sixth line
+  + Sixth line changed
+7   Seventh line
 ```

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Compare Result:
 
 The library currently supports two different types of diff outputs; the desired type can be specified during library initialization.
 
-`OutputType.Full` is the default. It shows the full contents of the verified file, with differences with the received file indicated by `+` and `-`. Here's an example of `Full` output.
+`OutputType.Full` is the default. It shows the full contents of the received file, with differences with the received file indicated by `+` and `-`. Here's an example of `Full` output.
 
 ```
   First line
@@ -82,16 +82,16 @@ The library currently supports two different types of diff outputs; the desired 
   Eighth line
 ```
 
-This output type gives the most information, but if your verified files are long, it can be difficult to read through and find the actual differences. `OutputType.Compact` will show only the changed lines, with one line of context before and after each changed section. The `Full` output above would look like this as `Compact`.
+This output type gives the most information, but if your verified files are long, it can be difficult to read through and find the actual differences. `OutputType.Compact` will show only the changed lines, with one line of context (with line number) before and after each changed section to help identify where the change is. The `Full` output above would look like this as `Compact`.
 
 ```
-1   First line
-  - Second line
-  + Second line changed
-3   Third line
+1 First line
+- Second line
++ Second line changed
+3 Third line
 
-5   Fifth line
-  - Sixth line
-  + Sixth line changed
-7   Seventh line
+5 Fifth line
+- Sixth line
++ Sixth line changed
+7 Seventh line
 ```

--- a/src/Tests/Tests.Bar.verified.txt
+++ b/src/Tests/Tests.Bar.verified.txt
@@ -1,0 +1,10 @@
+Line1
+Line2
+Line3
+Line4
+Line5
+Line6
+Line7
+Line8
+Line9
+Line10

--- a/src/Tests/Tests.Bar.verified.txt
+++ b/src/Tests/Tests.Bar.verified.txt
@@ -1,10 +1,12 @@
-Line1
-Line2
-Line3
-Line4
-Line5
-Line6
-Line7
-Line8
-Line9
-Line10
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+Line 8
+Line 9
+Line 10
+Line 11
+Line 12

--- a/src/Tests/Tests.Compact.verified.txt
+++ b/src/Tests/Tests.Compact.verified.txt
@@ -6,19 +6,26 @@ Differences:
 Received: Tests.Bar.received.txt
 Verified: Tests.Bar.verified.txt
 Compare Result:
-01   Line1
-   - Line2
-   + Line2 - changed
-03   Line3
+     [BOF]
+   - Line 1
+   + Line 1 changed
+02   Line 2
 
-05   Line5
-   + Line5a - added
-07   Line6
+04   Line 4
+   - Line 5
+   + Line 5 changed
+06   Line 6
+   - Line 7
+   + Added
+   + Line 7 changed
+09   Line 8
 
-09   Line8
-   - Line9
-10   Line10
-
+11   Line 10
+   - Line 11
+   - Line 12
+   + Line 11 changed
+   + Line 12 changed
+     [EOF]
 
 
 

--- a/src/Tests/Tests.Compact.verified.txt
+++ b/src/Tests/Tests.Compact.verified.txt
@@ -6,26 +6,26 @@ Differences:
 Received: Tests.Bar.received.txt
 Verified: Tests.Bar.verified.txt
 Compare Result:
-     [BOF]
-   - Line 1
-   + Line 1 changed
-02   Line 2
+   [BOF]
+ - Line 1
+ + Line 1 changed
+02 Line 2
 
-04   Line 4
-   - Line 5
-   + Line 5 changed
-06   Line 6
-   - Line 7
-   + Added
-   + Line 7 changed
-09   Line 8
+04 Line 4
+ - Line 5
+ + Line 5 changed
+06 Line 6
+ - Line 7
+ + Added
+ + Line 7 changed
+09 Line 8
 
-11   Line 10
-   - Line 11
-   - Line 12
-   + Line 11 changed
-   + Line 12 changed
-     [EOF]
+11 Line 10
+ - Line 11
+ - Line 12
+ + Line 11 changed
+ + Line 12 changed
+   [EOF]
 
 
 

--- a/src/Tests/Tests.Compact.verified.txt
+++ b/src/Tests/Tests.Compact.verified.txt
@@ -1,0 +1,25 @@
+﻿{
+  Type: VerifyException,
+  Message:
+Results do not match.
+Differences:
+Received: Tests.Bar.received.txt
+Verified: Tests.Bar.verified.txt
+Compare Result:
+01   Line1
+   - Line2
+   + Line2 - changed
+03   Line3
+
+05   Line5
+   + Line5a - added
+07   Line6
+
+09   Line8
+   - Line9
+10   Line10
+
+
+
+
+}

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -49,16 +49,19 @@ text";
 
         await Verifier.ThrowsTask(() =>
                 Verifier.Verify(
-                    @"Line1
-Line2 - changed
-Line3
-Line4
-Line5
-Line5a - added
-Line6
-Line7
-Line8
-Line10",
+                    @"Line 1 changed
+Line 2
+Line 3
+Line 4
+Line 5 changed
+Line 6
+Added
+Line 7 changed
+Line 8
+Line 9
+Line 10
+Line 11 changed
+Line 12 changed",
                     settings))
             .ScrubLinesContaining("DiffEngineTray");
     }

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -7,7 +7,6 @@ public class Tests
 {
     static Tests()
     {
-        VerifyDiffPlex.Initialize();
         VerifierSettings.DisableClipboard();
         VerifierSettings.ModifySerialization(
             settings => settings.IgnoreMember<Exception>(_ => _.StackTrace));
@@ -16,6 +15,7 @@ public class Tests
     [Test]
     public async Task Simple()
     {
+        VerifyDiffPlex.Initialize();
         var settings = new VerifySettings();
         settings.UseMethodName("Foo");
         settings.DisableDiff();
@@ -32,9 +32,35 @@ text",
     [Test]
     public async Task Sample()
     {
+        VerifyDiffPlex.Initialize();
         var target = @"The
 after
 text";
         await Verifier.Verify(target);
+    }
+
+    [Test]
+    public async Task Compact()
+    {
+        VerifyDiffPlex.Initialize(compact: true);
+        var settings = new VerifySettings();
+        settings.UseMethodName("Bar");
+        settings.DisableDiff();
+
+        await Verifier.ThrowsTask(() =>
+                Verifier.Verify(
+                    @"Line1
+Line2 - changed
+Line3
+Line4
+Line5
+Line5a - added
+Line6
+Line7
+Line8
+Line10",
+                    settings))
+            .ScrubLinesContaining("DiffEngineTray");
+
     }
 }

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -42,7 +42,7 @@ text";
     [Test]
     public async Task Compact()
     {
-        VerifyDiffPlex.Initialize(compact: true);
+        VerifyDiffPlex.Initialize(OutputType.Compact);
         var settings = new VerifySettings();
         settings.UseMethodName("Bar");
         settings.DisableDiff();
@@ -61,6 +61,5 @@ Line8
 Line10",
                     settings))
             .ScrubLinesContaining("DiffEngineTray");
-
     }
 }

--- a/src/Verify.DiffPlex/VerifyDiffPlex.cs
+++ b/src/Verify.DiffPlex/VerifyDiffPlex.cs
@@ -3,19 +3,27 @@ using DiffPlex.DiffBuilder.Model;
 
 namespace VerifyTests;
 
+public enum OutputType { Full, Compact }
+
 public static class VerifyDiffPlex
 {
-    public static void Initialize(bool compact = false)
+    public static void Initialize() => Initialize(OutputType.Full);
+    
+    public static void Initialize(OutputType outputType)
     {
+        Func<string, string, StringBuilder> compareFunc = outputType switch
+        {
+            OutputType.Compact => CompactCompare,
+            _ => VerboseCompare,
+        };
+        
         VerifierSettings.SetDefaultStringComparer((received, verified, _) =>
         {
-            Func<string, string, StringBuilder> compareFunc = compact ? CompactCompare : VerboseCompare;
             var builder = compareFunc(received, verified);
             
             var compareResult = CompareResult.NotEqual(builder.ToString());
             return Task.FromResult(compareResult);
         });
-
     }
 
     private static StringBuilder VerboseCompare(string received, string verified)

--- a/src/Verify.DiffPlex/VerifyDiffPlex.cs
+++ b/src/Verify.DiffPlex/VerifyDiffPlex.cs
@@ -5,32 +5,89 @@ namespace VerifyTests;
 
 public static class VerifyDiffPlex
 {
-    public static void Initialize()
+    public static void Initialize(bool compact = false)
     {
         VerifierSettings.SetDefaultStringComparer((received, verified, _) =>
         {
-            var diff = InlineDiffBuilder.Diff(verified, received);
-
-            var builder = new StringBuilder();
-            foreach (var line in diff.Lines)
-            {
-                switch (line.Type)
-                {
-                    case ChangeType.Inserted:
-                        builder.Append("+ ");
-                        break;
-                    case ChangeType.Deleted:
-                        builder.Append("- ");
-                        break;
-                    default:
-                        builder.Append("  ");
-                        break;
-                }
-                builder.AppendLine(line.Text);
-            }
-
+            Func<string, string, StringBuilder> compareFunc = compact ? CompactCompare : VerboseCompare;
+            var builder = compareFunc(received, verified);
+            
             var compareResult = CompareResult.NotEqual(builder.ToString());
             return Task.FromResult(compareResult);
         });
+
+    }
+
+    private static StringBuilder VerboseCompare(string received, string verified)
+    {
+        var diff = InlineDiffBuilder.Diff(verified, received);
+
+        var builder = new StringBuilder();
+        foreach (var line in diff.Lines)
+        {
+            switch (line.Type)
+            {
+                case ChangeType.Inserted:
+                    builder.Append("+ ");
+                    break;
+                case ChangeType.Deleted:
+                    builder.Append("- ");
+                    break;
+                default:
+                    builder.Append("  ");
+                    break;
+            }
+            builder.AppendLine(line.Text);
+        }
+
+        return builder;
+    }
+
+    private static StringBuilder CompactCompare(string received, string verified)
+    {
+        var diff = InlineDiffBuilder.Diff(verified, received);
+        var builder = new StringBuilder();
+
+        var paddingLength = diff.Lines.Max(l => l.Position).ToString().Length;
+        var defaultPadding = new String(' ', paddingLength);
+
+        bool IsChanged(DiffPiece? line) => line?.Type == ChangeType.Inserted || line?.Type == ChangeType.Deleted;
+
+        void AddToBuilder(int? lineNumber, string symbol, string text)
+        {
+            var padding = lineNumber?.ToString("D" + paddingLength) ?? defaultPadding;
+            builder.AppendLine($"{padding} {symbol} {text}");
+        }
+
+        DiffPiece? prevLine = null;
+        for (int i = 0; i < diff.Lines.Count; i++)
+        {
+            var currentLine = diff.Lines[i];
+            var nextLine = i < diff.Lines.Count - 1
+                ? diff.Lines[i + 1]
+                : null;
+
+            switch (currentLine.Type)
+            {
+                case ChangeType.Inserted:
+                    AddToBuilder(null, "+", currentLine.Text);
+                    break;
+                case ChangeType.Deleted:
+                    AddToBuilder(null, "-", currentLine.Text);
+                    break;
+                default:
+                    if (IsChanged(prevLine) || IsChanged(nextLine))
+                    {
+                        AddToBuilder(currentLine.Position, " ", currentLine.Text);
+                        if (IsChanged(prevLine))
+                            builder.AppendLine();
+                    }
+                    break;
+            }
+
+            prevLine = currentLine;
+        }
+
+        return builder;
     }
 }

--- a/src/Verify.DiffPlex/VerifyDiffPlex.cs
+++ b/src/Verify.DiffPlex/VerifyDiffPlex.cs
@@ -56,15 +56,15 @@ public static class VerifyDiffPlex
         var diff = InlineDiffBuilder.Diff(verified, received);
         var builder = new StringBuilder();
 
-        var paddingLength = diff.Lines.Max(l => l.Position).ToString().Length;
-        var defaultPadding = new String(' ', paddingLength);
+        var prefixLength = diff.Lines.Max(l => l.Position).ToString().Length;
+        var spacePrefix = new String(' ', prefixLength - 1);
 
         bool IsChanged(DiffPiece? line) => line?.Type == ChangeType.Inserted || line?.Type == ChangeType.Deleted;
 
         void AddDiffLine(int? lineNumber, string symbol, string text)
         {
-            var padding = lineNumber?.ToString("D" + paddingLength) ?? defaultPadding;
-            builder.AppendLine($"{padding} {symbol} {text}");
+            var prefix = lineNumber?.ToString("D" + prefixLength) ?? spacePrefix + symbol;
+            builder.AppendLine($"{prefix} {text}");
         }
 
         DiffPiece? prevLine = null;


### PR DESCRIPTION
I don't know if this is something you might be interested in or not. As noted in VerifyTests/Verify#425, I often have verified files that are a couple hundred lines long. Both the default output from Verify and the default output from Verify.DiffPlex wind up being very long and difficult to sift through.

What I've done is add a "compact" comparer that only outputs the actual changed lines, plus one line of context before and after. You can see the output [here](https://github.com/asherber/Verify.DiffPlex/blob/compact-output/src/Tests/Tests.Compact.verified.txt). I find this splits the difference between the default Verify.DiffPlex and the other solution I came up with using `Assert.Equals()`, which fails fast and only shows the first difference.

The compact comparer is used by calling `VerifyDiffPlex.Initialize(compact: true)`, though that could be changed to something like `VerifyDiffPlex.InitializeCompact()`. I'm happy to revise as needed.